### PR TITLE
Update rpi-display overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
@@ -61,7 +61,7 @@
 				buswidth = <8>;
 				reset-gpios = <&gpio 23 1>;
 				dc-gpios = <&gpio 24 0>;
-				led-gpios = <&gpio 18 0>;
+				led-gpios = <&gpio 18 1>;
 				debug = <0>;
 			};
 


### PR DESCRIPTION
Hi,
This will update the rpi-display overlay with new pin state definitions needed for kernel 5.10+.